### PR TITLE
Add `setGH!` and allow rotating residual matrix

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,7 +19,8 @@ makedocs(
             "Generalized Method of Moments" => "man/nonlineargmm.md",
             "Linear GMM" => "man/lineargmm.md",
             "Continuous-Updating GMM" => "man/cugmm.md",
-            "Bayesian Quasi-Likelihood" => "man/bayesian.md"
+            "Bayesian Quasi-Likelihood" => "man/bayesian.md",
+            "Advanced Usage" => "man/advanced.md"
             ],
         "References" => "refs.md"
     ],

--- a/docs/src/man/advanced.md
+++ b/docs/src/man/advanced.md
@@ -1,0 +1,51 @@
+# Advanced Usage
+
+For nonlinear problems requiring complicated moment conditions
+or a large number of repetitions,
+the [basic interface](@ref gdg) based on specifying the `g` and `dg` functions
+for individual observations may be suboptimal.
+In such circumstances,
+it is sufficient to customize the following methods
+in order to attain enhanced performance:
+
+| Method | Purpose |
+| :--- | :--- |
+| `setG!(est, g, θ)` | Update the mean of the residual vectors from the moment conditions |
+| `setGH!(est, g, θ)` | Update the individual residuals in addition to the mean updated by `setG!` |
+| `setdG!(est, dg, θ)` | Update the mean of the Jacobian matrices of residuals w.r.t. parameters |
+
+Above, `est` is a GMM estimator;
+`g` and `dg` are the user-defined objects passed from the basic interface via `fit`;
+`θ` is a `Vector` for the current candidate of parameter estimate.
+Details on how the computed values are stored can be found
+by inspecting the source code of the default implementation.
+Some estimators do not use `setG!` and only require `setGH!` and `setdG!`.
+
+Users defining customized methods should restrict the relevant type of `est`
+and the customized types for `g` and `dg`.
+To illustrate, one should have something like:
+```julia
+function MethodOfMoments.setG!(est::AbstractGMMEstimator{Nothing,Float64,false}, g::MyG, θ)
+    # My customized implementation goes here
+end
+```
+
+!!! info
+
+    `setG!`, `setGH!` and `setdG!` are the only functions
+    making use of `g` or `dg` for the estimation.
+    With a customized implementation of them,
+    `g` or `dg` can be repurposed as cache for intermediate results
+    instead of functions returning the computational results.
+
+For `setGH!`, where individual residuals need to be stored,
+performance depends on the shape of the residual matrix.
+For the nonlinear estimators,
+the residual matrix is *horizontal* by default.
+Namely, residual vectors from each observation are stacked as columns in a wide matrix.
+If this layout is not ideal for a customized implementation,
+one may switch to a vertical layout by simply passing
+`Val(false)` to the `horizontal` keyword argument of `fit`.
+In that case, residual vectors are expected to be stacked as rows in a tall matrix.
+All other functions that interact with the residual matrix
+will adjust their behavior accordingly.

--- a/docs/src/man/nonlineargmm.md
+++ b/docs/src/man/nonlineargmm.md
@@ -78,7 +78,7 @@ Y_i = \exp(\theta'\mathbf{X}_i) + \varepsilon_i
 ```
 is assumed to be orthogonal to a vector of instruments ``\mathbf{Z}_i``.
 
-## Specifying Moment Conditions and Their Derivatives
+## [Specifying Moment Conditions and Their Derivatives](@id gdg)
 
 The moment conditions and their derivatives with respect to the parameters
 need to be provided as Julia functions
@@ -177,6 +177,7 @@ dg = dg_stata_gmm_ex8(data)
     The users are recommended to profile these functions
     to ensure they have acceptable performance.
     Ideally, these functions should be non-allocating and type stable.
+    For complicated scenarios, see [Advanced Usage](@ref) for an alternative approach.
 
 ## Specifying Variance-Covariance Estimator
 

--- a/ext/MethodOfMomentsNLoptExt.jl
+++ b/ext/MethodOfMomentsNLoptExt.jl
@@ -54,11 +54,11 @@ function MM.iterate(m::NonlinearGMM{<:IteratedGMM,VCE,NLoptSolver}, state=1) whe
     m.solver.ret[] = r[3]
     # Last evaluation may not be at coef if the trial is rejected
     m.preg === nothing || m.preg(m.coef)
-    MM.setG!(m.est, m.g, m.coef)
+    MM.setGH!(m.est, m.g, m.coef)
     # Solver does not update dG in every step
     m.predg === nothing || m.predg(m.coef)
     MM.setdG!(m.est, m.dg, m.coef)
-    MM.setS!(m.vce, m.est.H)
+    MM.setS!(m.vce, m.est.H, MM.horizontal(m.est))
     m.est.iter[] += 1
     return m, state+1
 end
@@ -82,8 +82,8 @@ function MM.fit!(m::NonlinearGMM{<:CUGMM,VCE,NLoptSolver}; kwargs...) where VCE<
     # Last evaluation may not be at coef if the trial is rejected
     m.preg === nothing || m.preg(m.coef)
     est = m.est
-    MM.setG!(est, m.g, m.coef)
-    MM.setS!(est.vce, est.H)
+    MM.setGH!(est, m.g, m.coef)
+    MM.setS!(est.vce, est.H, MM.horizontal(est))
     copyto!(est.W, est.vce.S)
     inv!(cholesky!(est.W))
     # Solver does not update dG in every step
@@ -105,7 +105,7 @@ function MM.fit!(m::NonlinearGMM{<:LinearCUGMM,VCE,NLoptSolver}; kwargs...) wher
     # Last evaluation may not be at coef if the trial is rejected
     est = m.est
     MM.setH!(est.H, est.resids, est.Ys, est.Xs, est.Zs, m.coef, est.eqs)
-    MM.setS!(m.vce, est.H')
+    MM.setS!(m.vce, est.H, MM.horizontal(est))
     copyto!(est.Winv, m.vce.S)
     est.Winvfac[] = cholesky!(Hermitian(est.Winv))
     sum!(est.G, est.H')

--- a/src/bayesian.jl
+++ b/src/bayesian.jl
@@ -1,5 +1,5 @@
 struct BayesianGMM{PR<:Tuple, DF, VCE, G, DG, PG, PDG, P,
-        TF<:AbstractFloat} <: AbstractGMMEstimator{P,TF}
+        TF<:AbstractFloat, S} <: AbstractGMMEstimator{P,TF,S}
     coef::Vector{TF}
     vce::VCE
     l::RefValue{TF}
@@ -38,18 +38,20 @@ See documentation website for details.
 - `deriv=nothing`: specify how gradients for the quasi-posterior functions are computed.
 - `ntasks::Integer=_default_ntasks(nobs*nmoment)`: number of threads used for evaluating moment conditions and their derivatives across observations; only effective when `multithreaded=Val(true)`.
 - `multithreaded::Val{MT}=Val(true)`: use multiple threads.
+- `horizontal::Val{S}=Val(true)`: stack residuals from moment conditions across observations by column (`Val(true)`) or by row (`Val(false)`).
 - `TF::Type=Float64`: type of the numerical values.
 """
 function BayesianGMM(vce::CovarianceEstimator, g, dg,
         params, nmoment::Integer, nobs::Integer;
         preg=nothing, predg=nothing, deriv=nothing,
         ntasks::Integer=_default_ntasks(nobs*nmoment),
-        multithreaded::Val{MT}=Val(true), TF::Type=Float64) where MT
+        multithreaded::Val{MT}=Val(true),
+        horizontal::Val{S}=Val(true), TF::Type=Float64) where {MT,S}
     nparam = length(params)
     coef = Vector{TF}(undef, nparam)
     dl = Vector{TF}(undef, nparam)
-    # H is horizontal
-    H = Matrix{TF}(undef, nmoment, nobs)
+    # H is horizontal by default
+    H = S == true ? Matrix{TF}(undef, nmoment, nobs) : Matrix{TF}(undef, nobs, nmoment)
     G = Vector{TF}(undef, nmoment)
     WG = Vector{TF}(undef, nmoment)
     dG = Matrix{TF}(undef, nmoment, nparam)
@@ -64,14 +66,22 @@ function BayesianGMM(vce::CovarianceEstimator, g, dg,
         Gs = [Vector{TF}(undef, nmoment) for _ in 1:ntasks]
         dGs = [Matrix{TF}(undef, nmoment, nparam) for _ in 1:ntasks]
         p = PartitionedGMMTasks(rowcuts, Gs, dGs)
-        return BayesianGMM(coef, vce, Ref(NaN), dl, g, dg, preg, predg, H, G, WG, dG, W,
+        return BayesianGMM{typeof(priors), typeof(deriv), typeof(vce), typeof(g), typeof(dg),
+            typeof(preg), typeof(predg), typeof(p), TF, S}(
+            coef, vce, Ref(NaN), dl, g, dg, preg, predg, H, G, WG, dG, W,
             p, params, priors, deriv, dprior)
     else
-        return BayesianGMM(coef, vce, Ref(NaN), dl, g, dg, preg, predg, H, G, WG, dG, W,
+        return BayesianGMM{typeof(priors), typeof(deriv), typeof(vce), typeof(g), typeof(dg),
+            typeof(preg), typeof(predg), Nothing, TF, S}(
+            coef, vce, Ref(NaN), dl, g, dg, preg, predg, H, G, WG, dG, W,
             nothing, params, priors, deriv, dprior)
     end
 end
 
+nobs(m::BayesianGMM{<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,true}) =
+    size(m.H, 2)
+nobs(m::BayesianGMM{<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,false}) =
+    size(m.H, 1)
 coef(m::BayesianGMM) = m.coef
 coef(m::BayesianGMM, n::VarName) = m.coef[findfirst(==(n), m.params)]
 coefnames(m::BayesianGMM) = m.params
@@ -151,8 +161,8 @@ end
 function loglikelihood!(m::BayesianGMM, θ)
     copyto!(m.coef, θ)
     m.preg === nothing || m.preg(θ)
-    setG!(m, m.g, θ)
-    setS!(m.vce, m.H)
+    setGH!(m, m.g, θ)
+    setS!(m.vce, m.H, horizontal(m))
     copyto!(m.W, m.vce.S)
     try
         ldiv!(m.WG, cholesky!(Hermitian(m.W)), m.G)

--- a/src/cugmm.jl
+++ b/src/cugmm.jl
@@ -82,7 +82,7 @@ function fit(::Type{<:CUGMM}, solvertype, vce::CovarianceEstimator,
         multithreaded::Val{MT}=Val(true), horizontal::Val{S}=Val(true),
         initonly::Bool=false, solverkwargs=NamedTuple(), TF::Type=Float64) where {MT,S}
     checksolvertype(solvertype)
-    params, θ0 = _parse_params(params)
+    params, θ0 = _parse_params(params, TF)
     nparam = length(params)
     dg = _initdg(dg, g, params, nmoment)
     est = CUGMM(multithreaded, horizontal, nparam, nmoment, nobs, ntasks, vce; TF=TF)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -112,6 +112,15 @@ struct NonlinearGMM{TE<:AbstractGMMEstimator, VCE<:CovarianceEstimator, SOL,
     vce::VCE
     solver::SOL
     params::Vector{VarName}
+    function NonlinearGMM(coef, vcov, g, dg, preg, predg, est, vce, solver, params)
+        nparam(est) == nparam(vce) || throw(ArgumentError(
+            "Numbers of parameters of GMM and variance-covariance estimators do not match"))
+        nmoment(est) == nmoment(vce) || throw(ArgumentError(
+            "Numbers of moment conditions of GMM and variance-covariance estimators do not match"))
+        return new{typeof(est), typeof(vce), typeof(solver), typeof(g), typeof(dg),
+            typeof(preg), typeof(predg), eltype(coef)}(
+            coef, vcov, g, dg, preg, predg, est, vce, solver, params)
+    end
 end
 
 struct LinearGMM{TE<:AbstractGMMEstimator, VCE<:CovarianceEstimator,
@@ -122,4 +131,12 @@ struct LinearGMM{TE<:AbstractGMMEstimator, VCE<:CovarianceEstimator,
     vce::VCE
     eqs::Vector{Tuple{VarName,Vector{VarName},Vector{VarName}}} # Y, X, Z for each equation
     params::Vector{VarName}
+    function LinearGMM(coef, vcov, est, vce, eqs, params)
+        nparam(est) == nparam(vce) || throw(ArgumentError(
+            "Numbers of parameters of GMM and variance-covariance estimators do not match"))
+        nmoment(est) == nmoment(vce) || throw(ArgumentError(
+            "Numbers of moment conditions of GMM and variance-covariance estimators do not match"))
+        return new{typeof(est), typeof(vce), eltype(coef)}(
+            coef, vcov, est, vce, eqs, params)
+    end
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,4 +1,6 @@
-abstract type AbstractGMMEstimator{P, TF<:AbstractFloat} end
+abstract type AbstractGMMEstimator{P, TF<:AbstractFloat, S} end
+
+horizontal(::AbstractGMMEstimator{<:Any, <:Any, S}) where S = Val(S)
 
 abstract type AbstractGMMResult{TF<:AbstractFloat} <: StatisticalModel end
 

--- a/src/iteratedgmm.jl
+++ b/src/iteratedgmm.jl
@@ -4,7 +4,7 @@ struct PartitionedGMMTasks{TF}
     dGs::Vector{Matrix{TF}}
 end
 
-struct IteratedGMM{P,TF} <: AbstractGMMEstimator{P,TF}
+struct IteratedGMM{P,TF,S} <: AbstractGMMEstimator{P,TF,S}
     iter::RefValue{Int}
     Q::RefValue{TF}
     θlast::Vector{TF}
@@ -19,11 +19,10 @@ struct IteratedGMM{P,TF} <: AbstractGMMEstimator{P,TF}
     p::P
 end
 
-function IteratedGMM(::Val{MT}, nparam::Integer, nmoment::Integer, nobs::Integer,
-        ntasks::Integer; TF::Type=Float64) where MT
+function IteratedGMM(::Val{MT}, ::Val{S}, nparam::Integer, nmoment::Integer, nobs::Integer,
+        ntasks::Integer; TF::Type=Float64) where {MT,S}
     θlast = Vector{TF}(undef, nparam)
-    # H is horizontal
-    H = Matrix{TF}(undef, nmoment, nobs)
+    H = S == true ? Matrix{TF}(undef, nmoment, nobs) : Matrix{TF}(undef, nobs, nmoment)
     G = Vector{TF}(undef, nmoment)
     WG = Vector{TF}(undef, nmoment)
     dG = Matrix{TF}(undef, nmoment, nparam)
@@ -37,14 +36,17 @@ function IteratedGMM(::Val{MT}, nparam::Integer, nmoment::Integer, nobs::Integer
         Gs = [Vector{TF}(undef, nmoment) for _ in 1:ntasks]
         dGs = [Matrix{TF}(undef, nmoment, nparam) for _ in 1:ntasks]
         p = PartitionedGMMTasks(rowcuts, Gs, dGs)
-        return IteratedGMM(Ref(0), Ref(NaN), θlast, Ref(NaN), H, G, WG, dG, W, Wfac, Wup, p)
+        return IteratedGMM{typeof(p),TF,S}(Ref(0), Ref(NaN), θlast, Ref(NaN),
+            H, G, WG, dG, W, Wfac, Wup, p)
     else
-        return IteratedGMM(Ref(0), Ref(NaN), θlast, Ref(NaN), H, G, WG, dG, W, Wfac, Wup, nothing)
+        return IteratedGMM{Nothing,TF,S}(Ref(0), Ref(NaN), θlast, Ref(NaN),
+            H, G, WG, dG, W, Wfac, Wup, nothing)
     end
 end
 
-# ! H is horizontal
-nobs(est::IteratedGMM) = size(est.H, 2)
+# ! H is horizontal by default
+nobs(est::IteratedGMM{<:Any,<:Any,true}) = size(est.H, 2)
+nobs(est::IteratedGMM{<:Any,<:Any,false}) = size(est.H, 1)
 nparam(est::IteratedGMM) = size(est.dG, 2)
 nmoment(est::IteratedGMM) = length(est.G)
 
@@ -89,6 +91,7 @@ See documentation website for details.
 - `maxiter::Integer=10000`: maximum number of iterations allowed.
 - `ntasks::Integer=_default_ntasks(nobs*nmoment)`: number of threads used for evaluating moment conditions and their derivatives across observations; only effective when `multithreaded=Val(true)`.
 - `multithreaded::Val{MT}=Val(true)`: use multiple threads.
+- `horizontal::Val{S}=Val(true)`: stack residuals from moment conditions across observations by column (`Val(true)`) or by row (`Val(false)`).
 - `showtrace::Bool=false`: print information as iteration proceeds.
 - `initonly::Bool=false`: initialize the returned object without conducting the estimation.
 - `solverkwargs=NamedTuple()`: keyword arguments passed to the optimization solver as a `NamedTuple`.
@@ -100,12 +103,13 @@ function fit(::Type{<:IteratedGMM}, solvertype, vce::CovarianceEstimator,
         winitial=I, θtol::Real=1e-8, maxiter::Integer=10000,
         ntasks::Integer=_default_ntasks(nobs*nmoment),
         multithreaded::Val{MT}=Val(true), showtrace::Bool=false,
-        initonly::Bool=false, solverkwargs=NamedTuple(), TF::Type=Float64) where MT
+        horizontal::Val{S}=Val(true),
+        initonly::Bool=false, solverkwargs=NamedTuple(), TF::Type=Float64) where {MT,S}
     checksolvertype(solvertype)
     params, θ0 = _parse_params(params)
     nparam = length(params)
     dg = _initdg(dg, g, params, nmoment)
-    est = IteratedGMM(multithreaded, nparam, nmoment, nobs, ntasks; TF=TF)
+    est = IteratedGMM(multithreaded, horizontal, nparam, nmoment, nobs, ntasks; TF=TF)
     # Must initialize W before initializing solver
     copyto!(est.W, winitial)
     est.Wfac[] = cholesky(Hermitian(est.W))
@@ -122,6 +126,34 @@ function setG!(est::AbstractGMMEstimator{Nothing,TF}, g, θ) where TF
     N = size(est.H, 2)
     fill!(est.G, zero(TF))
     for r in 1:N
+        est.G .+= g(θ, r)
+    end
+    est.G ./= N
+end
+
+function setG!(est::AbstractGMMEstimator{<:PartitionedGMMTasks,TF}, g, θ) where TF
+    rowcuts = est.p.rowcuts
+    ntasks = length(rowcuts) - 1
+    @sync for i in 1:ntasks
+        Threads.@spawn begin
+            G = est.p.Gs[i]
+            fill!(G, zero(TF))
+            for r in rowcuts[i]:rowcuts[i+1]-1
+                G .+= g(θ, r)
+            end
+        end
+    end
+    fill!(est.G, zero(TF))
+    for i in 1:ntasks
+        est.G .+= est.p.Gs[i]
+    end
+    est.G ./= rowcuts[end]-1
+end
+
+function setGH!(est::AbstractGMMEstimator{Nothing,TF,true}, g, θ) where TF
+    N = size(est.H, 2)
+    fill!(est.G, zero(TF))
+    for r in 1:N
         h = g(θ, r)
         est.H[:,r] .= h
         est.G .+= h
@@ -129,7 +161,7 @@ function setG!(est::AbstractGMMEstimator{Nothing,TF}, g, θ) where TF
     est.G ./= N
 end
 
-function setG!(est::AbstractGMMEstimator{<:PartitionedGMMTasks,TF}, g, θ) where TF
+function setGH!(est::AbstractGMMEstimator{<:PartitionedGMMTasks,TF,true}, g, θ) where TF
     rowcuts = est.p.rowcuts
     ntasks = length(rowcuts) - 1
     @sync for i in 1:ntasks
@@ -252,13 +284,13 @@ function iterate(m::NonlinearGMM{<:IteratedGMM,VCE,<:NonlinearSystem},
     copyto!(m.coef, m.solver.x)
     # Last evaluation may not be at coef if the trial is rejected
     m.preg === nothing || m.preg(m.coef)
-    setG!(est, m.g, m.coef)
+    setGH!(est, m.g, m.coef)
     # Solver does not update dG in every step
     m.predg === nothing || m.predg(m.coef)
     setdG!(est, m.dg, m.coef)
     mul!(est.WG, est.W, est.G)
     est.Q[] = est.G'est.WG
-    setS!(m.vce, est.H)
+    setS!(m.vce, est.H, horizontal(est))
     est.iter[] += 1
     return m, state+1
 end

--- a/src/iteratedgmm.jl
+++ b/src/iteratedgmm.jl
@@ -102,9 +102,9 @@ function fit(::Type{<:IteratedGMM}, solvertype, vce::CovarianceEstimator,
         preg=nothing, predg=nothing,
         winitial=I, θtol::Real=1e-8, maxiter::Integer=10000,
         ntasks::Integer=_default_ntasks(nobs*nmoment),
-        multithreaded::Val{MT}=Val(true), showtrace::Bool=false,
-        horizontal::Val{S}=Val(true),
-        initonly::Bool=false, solverkwargs=NamedTuple(), TF::Type=Float64) where {MT,S}
+        multithreaded::Val{MT}=Val(true), horizontal::Val{S}=Val(true),
+        showtrace::Bool=false, initonly::Bool=false,
+        solverkwargs=NamedTuple(), TF::Type=Float64) where {MT,S}
     checksolvertype(solvertype)
     params, θ0 = _parse_params(params, TF)
     nparam = length(params)

--- a/src/iteratedgmm.jl
+++ b/src/iteratedgmm.jl
@@ -106,7 +106,7 @@ function fit(::Type{<:IteratedGMM}, solvertype, vce::CovarianceEstimator,
         horizontal::Val{S}=Val(true),
         initonly::Bool=false, solverkwargs=NamedTuple(), TF::Type=Float64) where {MT,S}
     checksolvertype(solvertype)
-    params, θ0 = _parse_params(params)
+    params, θ0 = _parse_params(params, TF)
     nparam = length(params)
     dg = _initdg(dg, g, params, nmoment)
     est = IteratedGMM(multithreaded, horizontal, nparam, nmoment, nobs, ntasks; TF=TF)

--- a/src/lineargmm.jl
+++ b/src/lineargmm.jl
@@ -1,4 +1,4 @@
-struct IteratedLinearGMM{TF} <: AbstractGMMEstimator{Nothing,TF}
+struct IteratedLinearGMM{TF} <: AbstractGMMEstimator{Nothing,TF,false}
     iter::RefValue{Int}
     Q::RefValue{TF}
     θlast::Vector{TF}
@@ -175,7 +175,7 @@ function iterate(m::LinearGMM{<:IteratedLinearGMM,VCE}, state=1) where VCE
     est.G ./= size(est.H, 1)
     state == 1 ? mul!(est.WG, est.Winv, est.G) : ldiv!(est.WG, est.Winvfac[], est.G)
     est.Q[] = est.G'est.WG
-    setS!(m.vce, est.H')
+    setS!(m.vce, est.H, Val(false))
     est.iter[] += 1
     return m, state+1
 end
@@ -206,7 +206,7 @@ show(io::IO, ::MIME"text/plain", est::IteratedLinearGMM; twolines::Bool=false) =
     (println(io, "Iterated Linear GMM estimator:"); print(io, "  ");
         _show_trace(io, est, false, twolines))
 
-struct JustIdentifiedLinearGMM{TF} <: AbstractGMMEstimator{Nothing,TF}
+struct JustIdentifiedLinearGMM{TF} <: AbstractGMMEstimator{Nothing,TF,false}
     Ys::Vector{Vector{TF}}
     Xs::Vector{Matrix{TF}}
     Zs::Vector{Matrix{TF}}
@@ -283,7 +283,7 @@ function fit!(m::LinearGMM{<:JustIdentifiedLinearGMM})
     copyto!(est.ZXinv, est.ZX)
     mul!(m.coef, inv!(lu!(est.ZXinv)), est.ZY)
     setH!(est.H, est.resids, est.Ys, est.Xs, est.Zs, m.coef, m.eqs)
-    setS!(m.vce, est.H')
+    setS!(m.vce, est.H, Val(false))
     try
         setvcov!(m)
     catch

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -29,9 +29,9 @@ end
 
 const VarName = Union{Symbol, Int}
 
-function _parse_params(ps::Union{AbstractVector{<:Pair}, Base.Pairs})
+function _parse_params(ps::Union{AbstractVector{<:Pair}, Base.Pairs}, TF::Type)
     names = Vector{VarName}(undef, length(ps))
-    initvals = Vector{Float64}(undef, length(ps))
+    initvals = Vector{TF}(undef, length(ps))
     for (i, p) in enumerate(ps)
         names[i] = p[1]
         initvals[i] = p[2]
@@ -39,21 +39,21 @@ function _parse_params(ps::Union{AbstractVector{<:Pair}, Base.Pairs})
     return names, initvals
 end
 
-_parse_params(ps::NamedTuple) = _parse_params(pairs(ps))
+_parse_params(ps::NamedTuple, TF::Type) = _parse_params(pairs(ps), TF::Type)
 
-_parse_params(ps::AbstractVector{<:VarName}) =
-    collect(VarName, ps), zeros(length(ps))
+_parse_params(ps::AbstractVector{<:VarName}, TF::Type) =
+    collect(VarName, ps), zeros(TF, length(ps))
 
-function _parse_params(ps::Tuple)
+function _parse_params(ps::Tuple, TF::Type)
     names = Vector{VarName}(undef, length(ps))
-    initvals = Vector{Float64}(undef, length(ps))
+    initvals = Vector{TF}(undef, length(ps))
     for (i, p) in enumerate(ps)
         if p isa Pair
             names[i] = p[1]
             initvals[i] = p[2]
         elseif p isa VarName
             names[i] = p
-            initvals[i] = 0.0
+            initvals[i] = zero(TF)
         else
             throw(ArgumentError("invalid specification of params"))
         end

--- a/test/bayesian.jl
+++ b/test/bayesian.jl
@@ -9,6 +9,8 @@
     θ = [0.5, 1, 1, 0.1, 0.1]
 
     @test m.p === nothing
+    @test horizontal(m) == Val(true)
+    @test nobs(m) == length(data) == size(m.H,2)
     @test dimension(m) == length(params)
     @test capabilities(m) == LogDensityOrder{1}()
     lpri = logprior(m, θ)
@@ -32,6 +34,11 @@
         BayesianGMM with 7 moments and 5 parameters:
           private = 5.00000e-01  chronic = 1.00000e+00  female = 1.00000e+00  income = 1.00000e-01  cons = 1.00000e-01
           log(posterior) = -2.6803"""
+
+    m = BayesianGMM(vce, g, dg, params, 7, length(data),
+        multithreaded=Val(false), horizontal=Val(false))
+    @test horizontal(m) == Val(false)
+    @test nobs(m) == length(data) == size(m.H,1)
 
     m1 = BayesianGMM(vce, g, dg, collect(params), 7, length(data);
         deriv=ForwardDiff, ntasks=2)

--- a/test/iteratedgmm.jl
+++ b/test/iteratedgmm.jl
@@ -289,5 +289,5 @@ end
 
     @test _default_ntasks(100_000) == Threads.nthreads() ÷ 2
     @test _default_ntasks(1_000_000) == Threads.nthreads()
-    @test_throws ArgumentError _parse_params((0.0,))
+    @test_throws ArgumentError _parse_params((0.0,), Float64)
 end

--- a/test/lineargmm.jl
+++ b/test/lineargmm.jl
@@ -3,6 +3,7 @@
     vce = RobustVCE(3, 6, size(data,1))
     eq = (:rent, (:hsngval, :pcturban), (:pcturban, :faminc, Symbol.(:reg, 2:4)...))
     r = fit(IteratedLinearGMM, vce, data, eq, maxiter=1)
+    @test horizontal(r.est) == Val(false)
     # Compare results with Stata GMM Example 2
     # gmm (rent - {xb:hsngval pcturban _cons}),
     #    instruments(pcturban faminc reg2-reg4) vce(unadjusted) onestep
@@ -105,6 +106,7 @@ end
     vce = RobustVCE(3, 3, size(data,1))
     eq = (:mpg, [:weight, :length])
     r = fit(JustIdentifiedLinearGMM, vce, data, eq)
+    @test horizontal(r.est) == Val(false)
     # gmm (mpg - {b1}*weight - {b2}*length - {b0}), instruments(weight length) onestep
     @test coef(r) ≈ [-0.00385148, -0.07959347, 47.884873] atol=1e-6
     @test stderror(r) ≈ [0.0019472, 0.0677536, 7.506064] atol=1e-4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,8 @@ using LinearAlgebra
 using LogDensityProblems: LogDensityOrder, capabilities, dimension, logdensity,
     logdensity_and_gradient
 using MCMCChains
-using MethodOfMoments: VarName, PartitionedGMMTasks, checksolvertype, acceptance_rate,
+using MethodOfMoments: AbstractGMMEstimator, VarName, PartitionedGMMTasks,
+    horizontal, setS!, checksolvertype, acceptance_rate,
     _default_ntasks, _parse_params, _parse_eqs, _parse_bayes_params, _parse_deriv
 using NLopt
 using Printf


### PR DESCRIPTION
Use `setGH!` instead of `setG!` when residuals need to be updated. `setG!` is now dedicated for the case when residuals across individual observations do not need to be updated (e.g., when solving each iteration step for `IterativeGMM` given `W`). This allows more flexibility when specifying the moment conditions directly with `setGH!`, `setG!` and `setdG!`.

For nonlinear estimators, residual matrices can now be rotated with keyword `horizontal` to accommodate customized `setGH!` that requires stacking residuals by row.