### PR TITLE
Allow swapping moment conditions with `fit!`

### DIFF
--- a/src/MethodOfMoments.jl
+++ b/src/MethodOfMoments.jl
@@ -7,7 +7,7 @@ using GroupedArrays: GroupedArray, GroupedVector
 using LinearAlgebra: I, mul!, ldiv!, inv!, Hermitian, Cholesky, cholesky!, cholesky, lu!, diagm
 using LogDensityProblems: LogDensityOrder
 using MacroTools
-using NonlinearSystems: NonlinearSystem, init, solve!, Hybrid, LeastSquares
+using NonlinearSystems: NonlinearSystem, LeastSquares, Hybrid, HybridSolver, init, solve!
 using Printf
 using StatsAPI: StatisticalModel
 using StatsBase: CovarianceEstimator, CoefTable, TestStat, PValue

--- a/src/cugmm.jl
+++ b/src/cugmm.jl
@@ -95,13 +95,36 @@ function fit(::Type{<:CUGMM}, solvertype, vce::CovarianceEstimator,
     return m
 end
 
+"""
+    fit!(m::NonlinearGMM{<:CUGMM,VCE,<:NonlinearSystem}, g, dg, params; kwargs...)
+
+An in-place version of [`fit`](@ref) with preallocated `m`
+that allows swapping moment conditions `g` and associated derivatives `dg`
+for parameters `params`.
+The numbers of moment conditions, parameters and observations
+must all remain unchanged from `m`.
+This method is intended for repeating estimation of different specifications
+when existing arrays can be reused.
+
+!!! warning
+
+    Use of this method requires caution,
+    as the method cannot verify whether the numbers of moment conditions
+    and observations indeed remain unchanged
+    with the respecified `g` and `dg`.
+
+# Keywords
+- `preg=nothing`: a function for processing the data frame before evaluating moment conditions.
+- `predg=nothing`: a function for processing the data frame before evaluating the derivatives for moment conditions.
+- `initonly::Bool=false`: initialize the returned object without conducting the estimation.
+- `solverkwargs=NamedTuple()`: keyword arguments passed to the optimization solver as a `NamedTuple`.
+"""
 function fit!(m::NonlinearGMM{<:CUGMM,VCE,<:NonlinearSystem}, g, dg, params;
         preg=nothing, predg=nothing, initonly::Bool=false,
         solverkwargs=NamedTuple()) where VCE
-    TF, nmm = eltype(m.coef), nmoment(m)
-    params, θ0 = _parse_params(params, TF)
+    params, θ0 = _parse_params(params, eltype(m.coef))
     length(params) == nparam(m) || error("Number of parameters cannot be changed")
-    dg = _initdg(dg, g, params, nmm)
+    dg = _initdg(dg, g, params, nmoment(m))
     est = m.est
     est.Q[] = NaN
     solver = _initsolver(_solvertype(m), est, g, dg, preg, predg, θ0; solverkwargs...)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -123,6 +123,9 @@ struct NonlinearGMM{TE<:AbstractGMMEstimator, VCE<:CovarianceEstimator, SOL,
     end
 end
 
+_solvertype(m::NonlinearGMM{<:Any,<:Any,
+    <:NonlinearSystem{<:Any,<:Any,<:Any,<:HybridSolver}}) = Hybrid
+
 struct LinearGMM{TE<:AbstractGMMEstimator, VCE<:CovarianceEstimator,
         TF} <: AbstractGMMResult{TF}
     coef::Vector{TF}

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -95,7 +95,7 @@ function show(io::IO, mime::MIME"text/plain", m::AbstractGMMResult)
     print(io, "  ")
     show(io, mime, m.est; twolines=true)
     println(io, "\n  ", m.vce)
-    show(io, coeftable(m))
+    show(io, mime, coeftable(m))
 end
 
 show(io::IO, est::AbstractGMMEstimator) = print(io, typeof(est).name.name)

--- a/src/iteratedgmm.jl
+++ b/src/iteratedgmm.jl
@@ -122,12 +122,39 @@ function fit(::Type{<:IteratedGMM}, solvertype, vce::CovarianceEstimator,
     return m
 end
 
+"""
+    fit!(m::NonlinearGMM{<:IteratedGMM}, g, dg, params; kwargs...)
+
+An in-place version of [`fit`](@ref) with preallocated `m`
+that allows swapping moment conditions `g` and associated derivatives `dg`
+for parameters `params`.
+The numbers of moment conditions, parameters and observations
+must all remain unchanged from `m`.
+This method is intended for repeating estimation of different specifications
+when existing arrays can be reused.
+
+!!! warning
+
+    Use of this method requires caution,
+    as the method cannot verify whether the numbers of moment conditions
+    and observations indeed remain unchanged
+    with the respecified `g` and `dg`.
+
+# Keywords
+- `preg=nothing`: a function for processing the data frame before evaluating moment conditions.
+- `predg=nothing`: a function for processing the data frame before evaluating the derivatives for moment conditions.
+- `winitial=I`: initial weight matrix; use identify matrix by default.
+- `θtol::Real=1e-8`: tolerance level for determining the convergence of parameters.
+- `maxiter::Integer=10000`: maximum number of iterations allowed.
+- `showtrace::Bool=false`: print information as iteration proceeds.
+- `initonly::Bool=false`: initialize the returned object without conducting the estimation.
+- `solverkwargs=NamedTuple()`: keyword arguments passed to the optimization solver as a `NamedTuple`.
+"""
 function fit!(m::NonlinearGMM{<:IteratedGMM}, g, dg, params;
         preg=nothing, predg=nothing,
         winitial=I, θtol::Real=1e-8, maxiter::Integer=10000,
-        showtrace::Bool=false, initonly::Bool=false,
-        solverkwargs=NamedTuple(), TF::Type=Float64)
-    params, θ0 = _parse_params(params, TF)
+        showtrace::Bool=false, initonly::Bool=false, solverkwargs=NamedTuple())
+    params, θ0 = _parse_params(params, eltype(m.coef))
     length(params) == nparam(m) || error("Number of parameters cannot be changed")
     dg = _initdg(dg, g, params, nmoment(m))
     est = m.est

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -154,6 +154,10 @@ function acceptance_rate(sample::AbstractVector)
     return count/(iN-i1+1)
 end
 
+# This makes sure combinations do not include the empty set
+# Behavior of combinations is changed with Combinatorics v1.1.0
+_combinations(a) = Iterators.flatten([combinations(a, k) for k = 1:length(a)])
+
 """
     datafile(name::Union{Symbol,String})
 

--- a/src/vce.jl
+++ b/src/vce.jl
@@ -77,7 +77,7 @@ function ClusterVCE(data, clusternames, nparam::Integer, nmoment::Integer;
     nclu = length(clusternames)
     clusters = map(n->GroupedArray(Tables.getcolumn(data, n), sort=nothing), clusternames)
     # Avoid allocations from combinations in setS!
-    Cs = collect(combinations(1:nclu))
+    Cs = collect(_combinations(1:nclu))
     G = minimum(x->x.ngroups, clusters)
     # Bring in combinations of clusters; order must follow combinations(1:nclu)
     for n in 2:nclu


### PR DESCRIPTION
For repeating estimation involving the same number of moment conditions, parameters and observations, may use `fit!` to reuse existing arrays.